### PR TITLE
Slight refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ guard-s3 is a simple guard library that syncs local directories with S3 as files
 
 # Usage
 
-This is a sample Guardfile that will automatically upload all files in the Guard *watchdir* directory into the specified s3 bucket. By default, *watchdir* is the directory from which guard was called, but it can be specified using the `--watchdir/-w` parameter.  See the [guard main documentation for details](https://github.com/guard/guard#guard----).
+This is a sample Guardfile that will automatically upload all files in the Guard *watchdir* directory into the specified S3 bucket. By default, *watchdir* is the directory from which guard was called, but it can be specified using the `--watchdir/-w` parameter.  See the [guard main documentation for details](https://github.com/guard/guard#guard----).
 
     opts = {
       :access_key_id      => 'ACCESS_KEY_ID_XXXXXX',
@@ -17,13 +17,20 @@ This is a sample Guardfile that will automatically upload all files in the Guard
       watch(/.*/)
     end
 
- 
+`prefix` is supported as a an option prefix to the key created on S3. e.g. `/prefix/path/to/file.txt`
 
 # Dependencies
 
  - guard
- - aws-s3
+ - aws-sdk
 
-# Changes this version
+# Changelog
 
+### 0.1.3 
+  - Added `prefix` to prefix S3 key.
+  - Compare file etag and upload if different (or not present).
+  - Support Guard v2.
+  - Switch to using Amazon aws-sdk for Ruby.
+
+### 0.1.2
  - Fixed `watchdir` behavior. Guard-s3 will now watch and upload from the directory path specified in the Guardfile relative to the guard `watchdir`.

--- a/guard-s3.gemspec
+++ b/guard-s3.gemspec
@@ -4,7 +4,7 @@ require 'guard/s3/version'
 
 Gem::Specification.new do |s|
   s.name        = "guard-s3"
-  s.version     = Guard::S3::VERSION
+  s.version     = Guard::S3Version::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["James Welsh", "Austin Mullins"]
   s.email       = ["james at supermatter dot com", "Austin dot Mullins at WalkeDesigns dot com"]
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'aws-s3'
-  s.add_dependency 'guard'
+  s.add_dependency 'aws-sdk', '~> 1.0'
+  s.add_dependency 'guard', '~> 2.0'
 end

--- a/lib/guard/s3/version.rb
+++ b/lib/guard/s3/version.rb
@@ -1,5 +1,5 @@
 module Guard
-  module S3
-    VERSION = "0.1.2"
+  class S3Version
+    VERSION = "0.1.3"
   end
 end


### PR DESCRIPTION
I made the following changes:
- Update to Guard v2 plugin system.
- Fixed "Undefined method options" error.
- Added support for a `prefix` to the uploaded S3 key. Use case is when uploading to a 'sub directory'
- Changed from `aws-s3` to the official `aws-sdk` for Ruby, as such there is better S3 API support and supports various [basic configuration options](https://github.com/aws/aws-sdk-ruby#basic-configuration)
- Compares `etag` (MD5 of the file) from S3 and uploads if different, current version does not replace if the file already exists.

This should be fully backwards compatible.
